### PR TITLE
取消分辨率限制v2

### DIFF
--- a/HsMod/Patcher.cs
+++ b/HsMod/Patcher.cs
@@ -315,18 +315,13 @@ namespace HsMod
                 return false;
 			}
 			//移除分辨率限制V2 
-			[HarmonyPrefix]
-			[HarmonyPatch(typeof(ResizeManagerV2), "Update")]
-			public static void PatchUpdate(object __instance)
-			{
-				// 反射拿私有字段 m_minResolutionResizeDelay
-				var f = AccessTools.Field(__instance.GetType(), "m_minResolutionResizeDelay");
-				if (f != null)
-				{
-					f.SetValue(__instance, Time.time + 10.0f);
-				}
-				// 不用 return false，继续跑原方法即可
-			}
+            [HarmonyPrefix]
+            [HarmonyPatch(typeof(ResizeManagerV2), "Update")]
+            public static bool PatchResizeManagerV2Update(ref float ___m_minResolutionResizeDelay)
+            {
+                ___m_minResolutionResizeDelay = UnityEngine.Time.time + 114514;
+                return true;
+            }
 
 			//命令行修改分辨率，阻止炉石自修改
 			[HarmonyPrefix]

--- a/HsMod/Patcher.cs
+++ b/HsMod/Patcher.cs
@@ -313,10 +313,23 @@ namespace HsMod
             {
                 __result = true;
                 return false;
-            }
+			}
+			//移除分辨率限制V2 
+			[HarmonyPrefix]
+			[HarmonyPatch(typeof(ResizeManagerV2), "Update")]
+			public static void PatchUpdate(object __instance)
+			{
+				// 反射拿私有字段 m_minResolutionResizeDelay
+				var f = AccessTools.Field(__instance.GetType(), "m_minResolutionResizeDelay");
+				if (f != null)
+				{
+					f.SetValue(__instance, Time.time + 10.0f);
+				}
+				// 不用 return false，继续跑原方法即可
+			}
 
-            //命令行修改分辨率，阻止炉石自修改
-            [HarmonyPrefix]
+			//命令行修改分辨率，阻止炉石自修改
+			[HarmonyPrefix]
             [HarmonyPatch(typeof(Screen), "SetResolution", new Type[] { typeof(int), typeof(int), typeof(bool) })]
             public static bool PatchSetResolution(ref int width, ref int height, ref bool fullscreen)
             {


### PR DESCRIPTION
## 概述 Overview

实现/解决/优化的内容 (implemented/solved/optimized/fixed):

* **取消分辨率限制 v2**

  * 移除原有最小分辨率 400×400 与比例限制，使窗口可自由缩放到更小分辨率。
  * 实现方式：基于 **延时判定 (delay) 原理**，在 `Update()` 前缀中将 `m_minResolutionResizeDelay` 强制同步为 `Time.time`，使 `(Time.time - m_minResolutionResizeDelay) <= 1f` 永远成立，从而阻断原逻辑中触发分辨率回退的分支。
  * 该方案不修改分辨率变更主流程，仅干预条件判断逻辑，确保兼容原框架与存档。

---

## 检查 Check

### 功能 Function

* [x] 若有新增，已编写完善的配置文件字段说明，并确保 `enUS.json` 已完善（本次无新增配置项）
* [x] 若有必要，已编写面向用户的新功能说明（说明中已注明取消分辨率与比例限制）
* [x] 已测试新功能或更改（窗口化 / 全屏 / 多分辨率边界测试通过）

---

### 风险 Risk

* 无明显功能性风险
