### PR TITLE
修复自动点击置换功能

### DIFF
--- a/HsMod/Patcher.cs
+++ b/HsMod/Patcher.cs
@@ -611,7 +611,7 @@ namespace HsMod
             //处理置换
             [HarmonyPostfix]
             [HarmonyPatch(typeof(RedundantNDEPopup), "Show")]
-            public static void AutoClickRedundantNDE(UIBButton ___m_rerollButton, MonoBehaviour __instance)
+            public static void AutoClickRedundantNDE(UIBButton ___m_rerollButton, RedundantNDEPopup __instance)
             {
                 if (!isAutoRedundantNDE.Value)
                     return;

--- a/HsMod/Patcher.cs
+++ b/HsMod/Patcher.cs
@@ -609,17 +609,23 @@ namespace HsMod
             }
 
             //处理置换
-            [HarmonyPrefix]
+            [HarmonyPostfix]
             [HarmonyPatch(typeof(RedundantNDEPopup), "Show")]
-            public static bool PatchRedundantNDEPopup(ref UIBButton ___m_rerollButton)
+            public static void AutoClickRedundantNDE(UIBButton ___m_rerollButton, MonoBehaviour __instance)
             {
                 if (!isAutoRedundantNDE.Value)
-                    return true;
+                    return;
 
-                ___m_rerollButton.TriggerPress();
-                ___m_rerollButton.TriggerRelease();
-                return false;
+                __instance.StartCoroutine(AutoClick(___m_rerollButton));
             }
+
+            private static IEnumerator AutoClick(UIBButton button)
+            {
+                yield return new WaitForSeconds(1f);
+                button.TriggerPress();
+                button.TriggerRelease();
+            }
+
             //处理未领取的奖励
             [HarmonyPostfix]
             [HarmonyPatch(typeof(RewardTrackSeasonRoll), "Show")]


### PR DESCRIPTION
## 概述 Overview

实现/解决/优化的内容（implemented/solved/optimized/fixed:）:
**修复 Redundant NDE 自动点击（Auto Reroll）功能失效的问题。**
原逻辑在 Harmony 前缀（`Prefix`）中过早触发按钮点击，导致 UI 元素尚未初始化、事件未注册，点击无效。
本次改动将逻辑调整为 **后置补丁（Postfix）+ 延迟协程执行**，保证弹窗完全加载后再自动触发“重掷”按钮，从而恢复自动点击功能的正常工作。

---

## 检查 Check

### 功能 Function

* [x] 若有新增，已编写完善的配置文件字段说明，并确保 `enUS.json` 已完善

  * 无
* [x] 若有必要，已编写面向用户的新功能说明

  * 功能未新增，仅修复逻辑错误，无需额外用户说明。
* [x] 已测试新功能或更改

  * 验证 `isAutoRedundantNDE = true` 时，弹窗在显示完成后 1 秒自动触发按钮事件。
  * 验证按钮事件响应正确，调用 `Network.Get().RespondToRedundantNDEReroll()`。
  * 验证 `isAutoRedundantNDE = false` 时行为不受影响。
  * 验证 UI 动画、Overlay 管理及关闭逻辑未受破坏。

---

### 风险 Risk

可能导致或已知的问题，如果没有，略过 (May cause or known problems, if there are none, skip):

  * 无

---
