### PR TITLE
增加Github Action: push时自动编译HsMod.dll并发布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: HsMod.dll Auto Build
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - run: dotnet restore
+      - run: dotnet build -c Release -p:RestoreLockedMode=true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: HsMod - Latest Auto Build
+          files: HsMod/Release/HsMod.dll
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
用AI写了个github action：

在push时自动编译HsMod.dll，并发布到 release。已测试可用。

或可以 Actions 处手动触发。